### PR TITLE
Separate message length and filtered words check for better notification messages

### DIFF
--- a/filter/init.lua
+++ b/filter/init.lua
@@ -126,11 +126,13 @@ function filter.on_violation(name, message, violation_type)
 			resolution = "kicked"
 			minetest.kick_player(name, v_type.kick_msg)
 			if discord and discord.enabled and (os.time() - last_kicked_time) > discordCooldown then
-				local blacklist_info = ""
+				local format_string = "***filter***: Kicked %s for %s \"%s\""
 				if violation_type == "blacklisted" then
-					blacklist_info = " caught with blacklist regex \"" .. filter.get_lastreg() .. "\""
+					format_string = "***filter***: Kicked %s for %s \"%s\" caught with blacklist regex \"%s\""
+					discord.send_action_report(format_string, name, v_type.name, last_bad_msg, filter.get_lastreg())
+				else
+					discord.send_action_report(format_string, name, v_type.name, last_bad_msg)
 				end
-				discord.send_action_report("***filter***: Kicked %s for " .. v_type.name .. " \"%s\"" .. blacklist_info, name, last_bad_msg)
 				last_kicked_time = os.time()
 			end
 		end

--- a/filter/src/lua.cpp
+++ b/filter/src/lua.cpp
@@ -20,7 +20,7 @@
 #define COMPATIBILITY
 
 static minetest m;
-static uint max_len = 20, mode = ENFORCING;
+static uint max_len = 1024, mode = ENFORCING;
 static QByteArray lastreg;
 static QString modpath, lastregwl;
 static std::forward_list<QRegularExpression> whitelist;

--- a/filter/src/lua.cpp
+++ b/filter/src/lua.cpp
@@ -180,9 +180,9 @@ int export_regex(lua_State *L)
 /* Args: token: string
  * Return: boolean
  */
-int is_blacklisted(lua_State *L)
+int is_message_too_long(lua_State *L)
 {
-	if (!check_args("is_blacklisted", L, 1, "token"))
+	if (!check_args("is_message_too_long", L, 1, "token"))
 		return 0;
 	QString token = lua_tostring(L, 1);
 	if (token.size() > max_len) {
@@ -190,6 +190,18 @@ int is_blacklisted(lua_State *L)
 		lua_pushboolean(L, true);
 		return 1;
 	}
+	lua_pushboolean(L, false);
+	return 1;
+}
+
+/* Args: token: string
+ * Return: boolean
+ */
+int is_blacklisted(lua_State *L)
+{
+	if (!check_args("is_blacklisted", L, 1, "token"))
+		return 0;
+	QString token = lua_tostring(L, 1);
 
 	bool res = false;
 	for (const QRegularExpression &reg : blacklist) {
@@ -249,6 +261,9 @@ void register_functions(lua_State* L)
 
 	lua_pushcfunction(L, is_blacklisted);
 	lua_setfield(L, -2, "is_blacklisted");
+
+	lua_pushcfunction(L, is_message_too_long);
+	lua_setfield(L, -2, "is_message_too_long");
 
 	lua_pushcfunction(L, export_regex);
 	lua_setfield(L, -2, "export_regex");


### PR DESCRIPTION
Give players specific feedback when they are muted for sending too long messages. Separate filter rules for better maintainability.

This pull request includes significant updates to the message filtering system in the `filter` module. The changes introduce new violation types, enhance message validation, and improve the handling of violations. The most significant changes are listed below:

### Introduction of Violation Types:

* Added a `violation_types` table to define different types of violations and their corresponding messages. (`filter/init.lua`)

### Enhanced Message Validation:

* Introduced a new function `is_message_too_long` to check if a message exceeds the allowed length. (`filter/init.lua`)
* Modified `filter.check_message` to return the type of violation if a message is blocked. (`filter/init.lua`)

### Improved Handling of Violations:

* Updated `filter.mute` to accept a `violation_type` parameter and use the appropriate messages from `violation_types`. (`filter/init.lua`)
* Enhanced `filter.show_warning_formspec` to display violation-specific warnings. (`filter/init.lua`)
* Adjusted `filter.on_violation` to handle different violation types and use appropriate messages for warnings, mutes, and kicks. (`filter/init.lua`)

### Integration with C++ Code:

* Added `is_message_too_long` function in the C++ code to check message length. (`filter/src/lua.cpp`)
* Registered the new `is_message_too_long` function in the Lua state. (`filter/src/lua.cpp`)